### PR TITLE
DM-52180b: Update stack image for daf_butler fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Prompt Processing Butler Writer service releases
 
+## 2.0.1
+
+Update the base stack image to `d_2025_09_05`, which contains an updated
+`daf_butler` to fix an issue where the service could not ingest into a Butler
+configured with a ChainedDatastore.
+
 ## 2.0.0
 Files are now assumed to have been written to their final location in the
 datastore prior to ingestion. This lets us avoid unnecessary S3 I/O. (See

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG PIPE_CONTAINER=ghcr.io/lsst/scipipe
-ARG STACK_TAG=w_latest
+ARG STACK_TAG=al9-d_2025_09_05
 FROM ${PIPE_CONTAINER}:${STACK_TAG}
 WORKDIR /app
 COPY python python


### PR DESCRIPTION
Update the base stack image to `d_2025_09_05`, which contains an updated `daf_butler` to fix an issue where the service could not ingest into a Butler configured with a ChainedDatastore.