### PR TITLE
DM-53143: Output lists of ingested datasets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,9 @@ pytest_session.txt
 .pytest_cache
 .coverage
 
+.env
+
 testrepo/
 staging-directory/
+output-directory/
 python/lsst_queued_butler_writer.dist-info

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Prompt Processing Butler Writer service releases
 
+## 3.0.0
+
+We now write lists of ingested datasets to S3, and send a Kafka message to
+signal that the new datasets are available in the Butler.  This will be
+consumed by the [DMTN-330](https://dmtn-330.lsst.io/) publication service.
+The environment variables controlling this, `OUTPUT_DATASET_LIST_DIRECTORY` and
+`KAFKA_OUTPUT_TOPIC`, are now required at startup.
+
+The base container has been updated to w_2025_48.
+
 ## 2.2.0
 
 We no longer record file sizes for ingested datasets in the Butler database.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG PIPE_CONTAINER=ghcr.io/lsst/scipipe
-ARG STACK_TAG=al9-d_2025_09_05
+ARG STACK_TAG=al9-w_2025_48
 FROM ${PIPE_CONTAINER}:${STACK_TAG}
 WORKDIR /app
 COPY python python

--- a/README.md
+++ b/README.md
@@ -39,12 +39,14 @@ scons
 
 # Start up the service.  Note that it has to be sourced, rather than invoked,
 # so that the LSST stack environment variables carry over.
-. ./run_service.sh
+. ./run_service.sh &
 
 # See python insert_test_messages.py --help for flags that control
 # which Butler data is inserted.
 python insert_test_messages.py
 ```
+
+This also starts up an instance of [kafdrop](https://kafdrop.com) on [localhost:9000](http://localhost:9000), which allows you to inspect the messages in Kafka.
 
 ## Build and Deploy
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,3 +43,13 @@ services:
       - broker
     image: apache/kafka:3.7.2
     command: /opt/kafka/bin/kafka-topics.sh --bootstrap-server broker:19092 --create --topic rubin-prompt-processing-butler-output
+  # Start up a web UI for Kafka, which can be viewed via HTTP port 9000.
+  kafdrop:
+    image: obsidiandynamics/kafdrop
+    restart: "no"
+    ports:
+      - "9000:9000"
+    environment:
+      KAFKA_BROKERCONNECT: "broker:19092"
+    depends_on:
+      - "broker"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       # We can't use the default configuration, because we want to be able to reach the container
       # from outside the Docker network.
       #
-      # From inside the Docker network, this node is known as "kafka-broker",
+      # From inside the Docker network, this node is known as "broker",
       # but when connecting from the local machine outside of Docker it is
       # "localhost".
       # See https://rmoff.net/2018/08/02/kafka-listeners-explained/
@@ -42,7 +42,12 @@ services:
     depends_on:
       - broker
     image: apache/kafka:3.7.2
-    command: /opt/kafka/bin/kafka-topics.sh --bootstrap-server broker:19092 --create --topic rubin-prompt-processing-butler-output
+    command: >
+      /bin/sh -c "
+      /opt/kafka/bin/kafka-topics.sh --bootstrap-server broker:19092 --create --topic writer-input
+      && /opt/kafka/bin/kafka-topics.sh --bootstrap-server broker:19092 --create --topic writer-output
+      "
+
   # Start up a web UI for Kafka, which can be viewed via HTTP port 9000.
   kafdrop:
     image: obsidiandynamics/kafdrop

--- a/insert_test_messages.py
+++ b/insert_test_messages.py
@@ -9,7 +9,7 @@ from lsst.queued_butler_writer.messages import PromptProcessingOutputEvent
 
 @click.command()
 @click.option("--broker", default="localhost:9092")
-@click.option("--topic", default="rubin-prompt-processing-butler-output")
+@click.option("--topic", default="writer-input")
 # By default, pull data from a copy of ci_hsc checked out adjacent to this
 # repository.
 @click.option("--input-repo", default="../ci_hsc_gen3/DATA")

--- a/python/lsst/__init__.py
+++ b/python/lsst/__init__.py
@@ -1,0 +1,3 @@
+import pkgutil
+
+__path__ = pkgutil.extend_path(__path__, __name__)

--- a/python/lsst/queued_butler_writer/kafka.py
+++ b/python/lsst/queued_butler_writer/kafka.py
@@ -22,54 +22,75 @@
 from __future__ import annotations
 
 import logging
-from collections.abc import Iterator
-from contextlib import contextmanager
+from typing import Callable, TypeAlias
 
-from confluent_kafka import Consumer, Message
+from confluent_kafka import Consumer, Message, Producer
 
 _LOG = logging.getLogger(__name__)
 
+MessageHandler: TypeAlias = Callable[[list[str]], list[str]]
+"""Callback function that takes a list of messages from Kafka as inputs, and
+returns a list of messages to send to Kafka as outputs."""
 
-class KafkaReader:
+
+class KafkaConnection:
     _BATCH_SIZE = 500
     _TIMEOUT_SECONDS = 30
 
-    def __init__(self, cluster: str, topic: str, username: str | None, password: str | None) -> None:
-        config = {
+    def __init__(
+        self, cluster: str, input_topic: str, output_topic: str, username: str | None, password: str | None
+    ) -> None:
+        common_config = {
             "bootstrap.servers": cluster,
+        }
+        if username is not None or password is not None:
+            assert username is not None, "If password is provided, username must also be set."
+            assert password is not None, "If username is provided, password must also be set."
+            common_config["security.protocol"] = "sasl_plaintext"
+            common_config["sasl.mechanism"] = "SCRAM-SHA-512"
+            common_config["sasl.username"] = username
+            common_config["sasl.password"] = password
+
+        consumer_config = common_config | {
             "group.id": "butler-writer",
             # Configure manual commit of read offsets to guarantee
             # at-least-once processing of messages.
             "enable.auto.commit": "false",  # allow use of Consumer.commit()
             "auto.offset.reset": "earliest",  # read from the beginning if there is no stored offset
         }
-        if username is not None:
-            assert password is not None, "If username is provided, password must also be set."
-            config["security.protocol"] = "sasl_plaintext"
-            config["sasl.mechanism"] = "SCRAM-SHA-512"
-            config["sasl.username"] = username
-            config["sasl.password"] = password
-        self._consumer = Consumer(config)
-        self._consumer.subscribe([topic])
+        self._consumer = Consumer(consumer_config)
+        self._consumer.subscribe([input_topic])
         self._pending_messages: list[Message] = []
+
+        producer_config = common_config | {"transactional.id": "butler-writer-output"}
+        self._output_topic = output_topic
+        self._producer = Producer(producer_config)
+        self._producer.init_transactions()
 
     def close(self) -> None:
         self._consumer.close()
 
-    @contextmanager
-    def read_messages(self) -> Iterator[list[str]]:
-        """Context manager returning a batch of messages read from Kafka.  If
-        the context manager is exited cleanly without the caller's code
-        throwing an exception, the messages are consumed and the read
-        position is committed to the Kafka broker.  If an exception is
-        thrown by the caller inside the context manager, the read position is
-        not committed and the same messages will be returned the next time
-        read_messages() is called.
+    def read_and_write_messages(self, callback: MessageHandler) -> None:
+        """Read a batch of messages from the Kafka consumer, write a batch of
+        messages to the Kafka producer, and store the consumer's read offsets
+        at the broker.  The entire sequence is atomic -- either BOTH the read
+        offsets and output messages are committed, or NEITHER is committed.
+        This guarantees at-least-once processing of the messages.
 
-        Returns
-        -------
-        messages
-            The list of messages read from Kafka, decoded as UTF-8 strings.
+        If this function completes successfully, it is guaranteed that both the
+        output messages and the read position have been committed
+        to the broker.
+
+        If an exception is thrown, it is unknown whether the transaction
+        completed successfully or failed.  In this case, the same messages will
+        be read the next time this function is called, and as a result it is
+        possible the messages may be processed more than once.
+
+        Parameters
+        ----------
+        callback : `Callable` [ [`list` [`str`] ], `list` [ `str` ] ]
+            Function that accepts a list of messages read from Kafka as input,
+            and returns a list of messages to be sent to Kafka.
         """
         # If we have some messages that we read out of Kafka but that the
         # caller failed to process, return them again.  This helps us guarantee
@@ -78,11 +99,20 @@ class KafkaReader:
         if not self._pending_messages:
             self._pending_messages = self._fetch_next_message_batch()
 
-        yield [msg.value().decode("utf-8") for msg in self._pending_messages]
-
-        # Permanently store our read position at the broker.
-        self._consumer.commit(asynchronous=False)
-        self._pending_messages = []
+        input_messages = [msg.value().decode("utf-8") for msg in self._pending_messages]
+        output_messages = callback(input_messages)
+        try:
+            self._producer.begin_transaction()
+            output_batch = [{"value": msg} for msg in output_messages]
+            self._producer.produce_batch(self._output_topic, output_batch)
+            self._producer.send_offsets_to_transaction(
+                self._consumer.position(self._consumer.assignment()), self._consumer.consumer_group_metadata()
+            )
+            self._producer.commit_transaction()
+            self._pending_messages = []
+        except Exception:
+            self._producer.abort_transaction()
+            raise
 
     def _fetch_next_message_batch(self) -> list[Message]:
         while True:
@@ -105,8 +135,9 @@ class KafkaReader:
                     raise RuntimeError(f"Error while reading Kafka messages: {errors}")
 
 
-class MockKafkaReader:
+class MockKafkaConnection:
     def __init__(self) -> None:
+        self.last_output: list[str] = []
         self._pending_messages: list[str] = []
 
     def add_messages(self, messages: list[str]) -> None:
@@ -115,7 +146,7 @@ class MockKafkaReader:
     def has_pending_messages(self) -> bool:
         return len(self._pending_messages) > 0
 
-    @contextmanager
-    def read_messages(self) -> Iterator[list[str]]:
-        yield self._pending_messages
+    def read_and_write_messages(self, callback: MessageHandler) -> None:
+        output = callback(self._pending_messages)
         self._pending_messages = []
+        self.last_output = output

--- a/python/lsst/queued_butler_writer/kafka.py
+++ b/python/lsst/queued_butler_writer/kafka.py
@@ -103,3 +103,19 @@ class KafkaReader:
                     return valid_messages
                 elif errors:
                     raise RuntimeError(f"Error while reading Kafka messages: {errors}")
+
+
+class MockKafkaReader:
+    def __init__(self) -> None:
+        self._pending_messages: list[str] = []
+
+    def add_messages(self, messages: list[str]) -> None:
+        self._pending_messages.extend(messages)
+
+    def has_pending_messages(self) -> bool:
+        return len(self._pending_messages) > 0
+
+    @contextmanager
+    def read_messages(self) -> Iterator[list[str]]:
+        yield self._pending_messages
+        self._pending_messages = []

--- a/python/lsst/queued_butler_writer/kafka.py
+++ b/python/lsst/queued_butler_writer/kafka.py
@@ -112,7 +112,9 @@ class KafkaConnection:
         try:
             self._producer.begin_transaction()
             output_batch = [{"value": msg} for msg in output_messages]
-            self._producer.produce_batch(self._output_topic, output_batch)
+            messages_produced = self._producer.produce_batch(self._output_topic, output_batch)
+            if len(output_batch) != messages_produced:
+                raise RuntimeError("Kafka produce failed.")
             self._producer.send_offsets_to_transaction(
                 self._consumer.position(self._consumer.assignment()), self._consumer.consumer_group_metadata()
             )

--- a/python/lsst/queued_butler_writer/kafka.py
+++ b/python/lsst/queued_butler_writer/kafka.py
@@ -118,7 +118,7 @@ class KafkaConnection:
         while True:
             messages = self._consumer.consume(self._BATCH_SIZE, self._TIMEOUT_SECONDS)
             if not messages:
-                _LOG.debug(f"Still waiting for Kafka message after {self._TIMEOUT_SECONDS} seconds")
+                _LOG.info(f"Still waiting for Kafka message after {self._TIMEOUT_SECONDS} seconds")
             else:
                 valid_messages = []
                 errors = []

--- a/python/lsst/queued_butler_writer/kafka.py
+++ b/python/lsst/queued_butler_writer/kafka.py
@@ -38,7 +38,13 @@ class KafkaConnection:
     _TIMEOUT_SECONDS = 30
 
     def __init__(
-        self, cluster: str, input_topic: str, output_topic: str, username: str | None, password: str | None
+        self,
+        cluster: str,
+        input_topic: str,
+        output_topic: str,
+        username: str | None,
+        password: str | None,
+        debug: bool = False,
     ) -> None:
         common_config = {
             "bootstrap.servers": cluster,
@@ -63,6 +69,8 @@ class KafkaConnection:
         self._pending_messages: list[Message] = []
 
         producer_config = common_config | {"transactional.id": "butler-writer-output"}
+        if debug:
+            producer_config["debug"] = "all"
         self._output_topic = output_topic
         self._producer = Producer(producer_config)
         self._producer.init_transactions()

--- a/python/lsst/queued_butler_writer/main.py
+++ b/python/lsst/queued_butler_writer/main.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 import datetime
 import logging
 import os
+from typing import Literal
 from uuid import uuid4
 
 import backoff
@@ -52,6 +53,8 @@ class ServiceConfig(pydantic.BaseModel):
     """
     KAFKA_USERNAME: str | None = None
     KAFKA_PASSWORD: str | None = None
+    KAFKA_DEBUG: Literal["0", "1"] = "0"
+    """If '1', enable additional kafka debug logging."""
     OUTPUT_DATASET_LIST_DIRECTORY: str
     """
     Directory URI (in `lsst.resources.ResourcePath` format) where lists of
@@ -78,6 +81,7 @@ def main():
         output_topic=config.KAFKA_OUTPUT_TOPIC,
         username=config.KAFKA_USERNAME,
         password=config.KAFKA_PASSWORD,
+        debug=config.KAFKA_DEBUG == "1",
     )
 
     processor = MessageProcessor(config, butler, reader)

--- a/python/lsst/queued_butler_writer/main.py
+++ b/python/lsst/queued_butler_writer/main.py
@@ -100,6 +100,7 @@ class MessageProcessor:
     )
     def process_messages(self) -> None:
         self._reader.read_and_write_messages(self._handle_messages)
+        _LOG.info("Committed output to Kafka.")
 
     def _handle_messages(self, messages: list[str]) -> list[str]:
         events = [PromptProcessingOutputEvent.model_validate_json(msg) for msg in messages]

--- a/python/lsst/queued_butler_writer/messages.py
+++ b/python/lsst/queued_butler_writer/messages.py
@@ -52,6 +52,7 @@ class BatchIngestedEvent(pydantic.BaseModel):
 
     type: Literal["batch-ingested"]
     batch_id: UUID
+    """Identifier for this batch of datasets."""
     origin: str
     """The name of the service that these datasets originated from."""
     batch_file: str
@@ -61,4 +62,11 @@ class BatchIngestedEvent(pydantic.BaseModel):
 
 
 class DatasetBatch(pydantic.BaseModel):
+    """List of datasets contained in JSON file that will be consumed by the
+    Prompt Publication Service.
+    """
+
+    batch_id: UUID
+    """Identifier for this batch of datasets."""
     datasets: list[UUID]
+    """List of dataset IDs that were ingested into the Butler database."""

--- a/run_service.sh
+++ b/run_service.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 
 export KAFKA_CLUSTER=localhost:9092
-export KAFKA_TOPIC=rubin-prompt-processing-butler-output
+export KAFKA_TOPIC=writer-input
+export KAFKA_OUTPUT_TOPIC=writer-output
 export BUTLER_REPOSITORY=$(dirname "$0")/testrepo
 export OUTPUT_DATASET_LIST_DIRECTORY=$(dirname "$0")/output-directory
 

--- a/run_service.sh
+++ b/run_service.sh
@@ -3,14 +3,15 @@
 export KAFKA_CLUSTER=localhost:9092
 export KAFKA_TOPIC=rubin-prompt-processing-butler-output
 export BUTLER_REPOSITORY=$(dirname "$0")/testrepo
-export FILE_STAGING_ROOT_PATH=$(dirname "$0")/staging-directory
+export OUTPUT_DATASET_LIST_DIRECTORY=$(dirname "$0")/output-directory
 
 docker compose up --detach --wait --remove-orphans
 echo Docker startup complete.
 if [ ! -f "$BUTLER_REPOSITORY/butler.yaml" ]; then
     echo Butler repository does not exist, creating it
-    butler create $BUTLER_REPOSITORY
+    butler create "$BUTLER_REPOSITORY"
 fi
+mkdir -p "$OUTPUT_DATASET_LIST_DIRECTORY"
 
 echo Starting service
 python -m lsst.queued_butler_writer.main

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -22,61 +22,100 @@
 import os
 import shutil
 import unittest
+from uuid import UUID
 from tempfile import TemporaryDirectory
 
 from lsst.daf.butler import Butler, DatasetType
-from lsst.queued_butler_writer.butler import handle_prompt_processing_completion
-from lsst.queued_butler_writer.messages import PromptProcessingOutputEvent
+from lsst.resources import ResourcePath
+from lsst.queued_butler_writer.main import MessageProcessor, ServiceConfig
+from lsst.queued_butler_writer.kafka import MockKafkaReader
+from lsst.queued_butler_writer.messages import BatchIngestedEvent, DatasetBatch
 
 
 class TestButlerWrite(unittest.TestCase):
-    def test_write(self):
+    def setUp(self) -> None:
+        self._butler_root = self.enterContext(TemporaryDirectory())
+        Butler.makeRepo(self._butler_root)
+        self._butler = Butler.from_config(self._butler_root, writeable=True)
+
+        self._output_dir = self.enterContext(TemporaryDirectory())
+        mock_config = ServiceConfig(
+            BUTLER_REPOSITORY="",
+            KAFKA_CLUSTER="",
+            KAFKA_TOPIC="",
+            OUTPUT_DATASET_LIST_DIRECTORY=f"file://{self._output_dir}",
+        )
+        self._kafka_reader = MockKafkaReader()
+        self._message_processor = MessageProcessor(mock_config, self._butler, self._kafka_reader)
+
+    def test_write(self) -> None:
         artifact_directory = os.path.join(self._get_data_directory(), "exported_artifacts")
-        with TemporaryDirectory() as butler_tempdir:
-            Butler.makeRepo(butler_tempdir)
-            # Copy the files into the Butler datastore directory so they can be
-            # found by ingest.
-            shutil.copytree(artifact_directory, butler_tempdir, dirs_exist_ok=True)
+        # Copy the files into the Butler datastore directory so they can be
+        # found by ingest.
+        shutil.copytree(artifact_directory, self._butler_root, dirs_exist_ok=True)
 
-            butler = Butler.from_config(butler_tempdir, writeable=True)
+        # Register a dataset type which is used by datasets in the
+        # messages, but not explicitly included there.
+        # If the dataset type is already registered in the target Butler,
+        # it does not have to be specified in the messages.
+        self._butler.registry.registerDatasetType(
+            DatasetType("dt2", ["instrument", "detector"], "int", universe=self._butler.dimensions)
+        )
 
-            # Register a dataset type which is used by datasets in the
-            # messages, but not explicitly included there.
-            # If the dataset type is already registered in the target Butler,
-            # it does not have to be specified in the messages.
-            butler.registry.registerDatasetType(
-                DatasetType("dt2", ["instrument", "detector"], "int", universe=butler.dimensions)
+        messages = [self._load_message(filename) for filename in ["message1.json", "message2.json"]]
+        self._kafka_reader.add_messages(messages)
+        output = self._message_processor.process_messages()
+        self.assertFalse(self._kafka_reader.has_pending_messages())
+        self.assertEqual(output.origin, "prompt_processing")
+        self.assertIn(str(output.batch_id), output.batch_file)
+        batch = self._read_output_batch(output)
+        self.assertCountEqual(
+            batch.datasets,
+            [
+                UUID("26c6235f-2ea3-5a15-8009-a3056e49c379"),
+                UUID("07f98c57-9075-5e6c-a710-8aa4bfbe74a3"),
+                UUID("58adc38b-0374-4656-9e7e-24d67792c02d"),
+            ],
+        )
+
+        # Make sure data was ingested into the target Butler.
+        self.assertEqual(
+            self._butler.get("dt1", {"instrument": "Cam1", "detector": 1}, collections="Cam1/run"), 1
+        )
+        self.assertEqual(
+            self._butler.get("dt2", {"instrument": "Cam1", "detector": 1}, collections="Cam1/run"), 2
+        )
+        self.assertEqual(
+            self._butler.get("dt1", {"instrument": "Cam1", "detector": 2}, collections="Cam1/run"), 3
+        )
+
+        with self.assertLogs(level="ERROR") as logs:
+            # Process a message that will trigger a
+            # ConflictingDefinitionError in the Butler, and ensure that we
+            # log the error but do not abort processing.
+            self._kafka_reader.add_messages([self._load_message("conflicting-message.json"), *messages])
+            output = self._message_processor.process_messages()
+            self.assertFalse(self._kafka_reader.has_pending_messages())
+            batch = self._read_output_batch(output)
+            self.assertCountEqual(
+                batch.datasets,
+                [
+                    UUID("26c6235f-2ea3-5a15-8009-a3056e49c379"),
+                    UUID("07f98c57-9075-5e6c-a710-8aa4bfbe74a3"),
+                    UUID("58adc38b-0374-4656-9e7e-24d67792c02d"),
+                ],
             )
-
-            messages = [self._load_message(filename) for filename in ["message1.json", "message2.json"]]
-            handle_prompt_processing_completion(butler, messages)
-
-            # Make sure data was ingested into the target Butler.
-            self.assertEqual(
-                butler.get("dt1", {"instrument": "Cam1", "detector": 1}, collections="Cam1/run"), 1
-            )
-            self.assertEqual(
-                butler.get("dt2", {"instrument": "Cam1", "detector": 1}, collections="Cam1/run"), 2
-            )
-            self.assertEqual(
-                butler.get("dt1", {"instrument": "Cam1", "detector": 2}, collections="Cam1/run"), 3
-            )
-
-            with self.assertLogs(level="ERROR") as logs:
-                # Process a message that will trigger a
-                # ConflictingDefinitionError in the Butler, and ensure that we
-                # log the error but do not abort processing.
-                handle_prompt_processing_completion(
-                    butler, [self._load_message("conflicting-message.json"), *messages]
-                )
-            self.assertTrue(any("Encountered unrecoverable error" in msg for msg in logs.output))
+        self.assertTrue(any("Encountered unrecoverable error" in msg for msg in logs.output))
 
     def _get_data_directory(self) -> str:
         test_directory = os.path.abspath(os.path.dirname(__file__))
         return os.path.join(test_directory, "data")
 
-    def _load_message(self, filename: str) -> PromptProcessingOutputEvent:
+    def _load_message(self, filename: str) -> str:
         path = os.path.join(self._get_data_directory(), filename)
         with open(path) as fh:
-            json = fh.read()
-            return PromptProcessingOutputEvent.model_validate_json(json)
+            return fh.read()
+
+    def _read_output_batch(self, message: BatchIngestedEvent) -> DatasetBatch:
+        batch_data = ResourcePath(self._output_dir).join(message.batch_file).read().decode("utf-8")
+        return DatasetBatch.model_validate_json(batch_data)


### PR DESCRIPTION
After ingesting a batch of datasets, the service now writes a file containing the list of dataset IDs that were ingested.  It also writes a Kafka message pointing to the file.  These will be read by the Prompt Publication Service to get the list of datasets that should be unembargoed.
