### PR TITLE
DM-53622: Add provenance recording to Prompt Processing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Prompt Processing Butler Writer service releases
 
+## Pending
+
+The base container has been updated to w_2026_04. This enables support for
+ProvenanceQuantumGraph datasets.
+
 ## 3.0.0
 
 We now write lists of ingested datasets to S3, and send a Kafka message to

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG PIPE_CONTAINER=ghcr.io/lsst/scipipe
-ARG STACK_TAG=al9-w_2025_48
+ARG STACK_TAG=al9-w_2026_04
 FROM ${PIPE_CONTAINER}:${STACK_TAG}
 WORKDIR /app
 COPY python python


### PR DESCRIPTION
This PR updates the base Science Pipelines container so that the writer can recognize `ProvenanceQuantumGraph` datasets.